### PR TITLE
Add formula

### DIFF
--- a/Formula/firefox-profile-switcher-connector.rb
+++ b/Formula/firefox-profile-switcher-connector.rb
@@ -1,0 +1,27 @@
+class FirefoxProfileSwitcherConnector < Formula
+
+    desc "The native component of the Profile Switcher for Firefox extension."
+    homepage "https://github.com/null-dev/firefox-profile-switcher-connector"
+    url "https://github.com/null-dev/firefox-profile-switcher-connector/archive/refs/tags/v0.0.6.tar.gz"
+    sha256 "40f0429f2aeebd128072a75674e132477ef1f16ce03d77704fa55395624a62fc"
+    version "0.0.6"
+    depends_on "rust" => :build
+
+    @@manifest_name = "ax.md.profile_switcher_ff.json"
+
+    def install
+      system "cargo", "build", "--release", "--bin", "firefox_profile_switcher_connector"
+      prefix.install "manifest/manifest-mac.json" => @@manifest_name
+      bin.install "target/release/firefox_profile_switcher_connector" => "ff-pswitch-connector"
+    end
+
+    def caveats
+      manifest_source = "#{HOMEBREW_CELLAR}/firefox-profile-switcher-connector/#{version}"
+      manifest_destination = "/Users/#{ENV["USER"]}/Library/Application Support/Mozilla/NativeMessagingHosts"
+      <<~EOS
+         The plugin manifest is installed but not linked in Firefox. Run the following to link it:
+          "ln -sf '#{manifest_source}/#{@@manifest_name}' '#{manifest_destination}/#{@@manifest_name}'"
+      EOS
+    end
+
+  end


### PR DESCRIPTION
This formula doesn't install the manifest file in Firefox. It asks the installer to run a command to link it. I wasn't able to get Homebrew to create a file in the User's home directory. There may be a solution to this issue, but I haven't been able to find it yet.

The follow will test the install from my repository for a pre-merge test:
```
brew tap matthardcastle/firefox-profile-switcher
brew install firefox-profile-switcher-connector
```

This will clean up brew after the test:
```
brew uninstall firefox-profile-switcher-connector
brew untap matthardcastle/firefox-profile-switcher
```

After merge the follow will install the connector:
```
brew tap null-dev/firefox-profile-switcher
brew install firefox-profile-switcher-connector
```